### PR TITLE
Changed to restore window state instead of moving cursor

### DIFF
--- a/autoload/operator/stay_cursor.vim
+++ b/autoload/operator/stay_cursor.vim
@@ -17,7 +17,7 @@ let s:default_config = {
 \}
 
 
-function! s:do(wise, op, pos, config)
+function! s:do(wise, op, view, config)
 	let old_selection = &selection
 	let &selection = 'inclusive'
 	let wise = s:as_wise_key(a:wise)
@@ -30,20 +30,20 @@ function! s:do(wise, op, pos, config)
 	finally
 		let &selection = old_selection
 	endtry
-	call setpos(".", a:pos)
+	call winrestview(a:view)
 endfunction
 
 
 function! operator#stay_cursor#wrapper(op, ...)
 	let s:config = extend(copy(s:default_config), get(a:, 1, {}))
-	let s:pos = getpos(".")
+	let s:view = winsaveview()
 	let s:operator = a:op
 	return "\<Plug>(operator-operator-stay-cursor-dummy)"
 endfunction
 
 
 function! operator#stay_cursor#do(wise)
-	return s:do(a:wise, s:operator, s:pos, s:config)
+	return s:do(a:wise, s:operator, s:view, s:config)
 endfunction
 
 call operator#user#define('operator-stay-cursor-dummy', 'operator#stay_cursor#do')


### PR DESCRIPTION
operatorの実行時に、カーソルの文書全体からの絶対位置は復元されるのですが、ウィンドウ中央部にカーソルが移動してしまう仕様がありました。

そこで`setpos`の代わりに`winsaveview`を用いることでウィンドウ上のカーソルの位置も復元できるようにしました。

マージのご検討よろしくお願いいたします。